### PR TITLE
Ki needs to affect the integral component, not the change in integral itself.

### DIFF
--- a/simple_pid/PID.py
+++ b/simple_pid/PID.py
@@ -105,13 +105,13 @@ class PID(object):
             self._proportional -= self.Kp * d_input
 
         # compute integral and derivative terms
-        self._integral += self.Ki * error * dt
+        self._integral += error * dt
         self._integral = _clamp(self._integral, self.output_limits)  # avoid integral windup
 
         self._derivative = -self.Kd * d_input / dt
 
         # compute final output
-        output = self._proportional + self._integral + self._derivative
+        output = self._proportional + (self.Ki * self._integral) + self._derivative
         output = _clamp(output, self.output_limits)
 
         # keep track of state


### PR DESCRIPTION
As the title states, the integral value should be just the accumulated product of `error * dt`.  Otherwise the integral product can either stick around too long, or be wiped out too quickly if/when Ki != 0.