### PR TITLE
Use MANIFEST.in for all needed files in PyPI sdist

### DIFF
--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -1,0 +1,12 @@
+include CHANGELOG.md
+include LICENSE.md
+include README.md
+
+recursive-exclude * __pycache__
+recursive-exclude * *.py[co]
+
+recursive-include docs *.rst conf.py Makefile requirements.txt
+recursive-include examples *.md *.txt *.py
+
+include simple_pid/*.pyi
+include simple_pid/py.typed

--- a/setup.py
+++ b/setup.py
@@ -1,5 +1,4 @@
-
-from setuptools import setup
+from setuptools import setup, find_packages
 
 from codecs import open
 from os import path
@@ -26,7 +25,7 @@ setup(
         'Programming Language :: Python :: 3',
     ],
     keywords='pid controller control',
-    packages=['simple_pid'],
+    packages=find_packages(),
     package_data={
         'simple_pid': ['*.pyi', 'py.typed'],
     },


### PR DESCRIPTION
Hi @m-lundberg! I am attempting to package this project with conda via https://github.com/nsls-ii-forge/simple-pid-feedstock/pull/1, however I noticed there are missing files in the source distribution archive uploaded to [PyPI](https://pypi.org/project/simple-pid/0.2.4/#files) (such as `.pyi` and other files). I think it's important to fix it, and this PR is attempting to do it.

## Comparison

### Preparation steps:
```bash
$ conda create -n test-env python=3.9 -y
$ conda activate test-env
$ git clone https://github.com/m-lundberg/simple-pid.git
$ cd simple-pid/
$ git remote add mrakitin https://github.com/mrakitin/simple-pid
$ git fetch mrakitin
```

### Before:
```bash
$ python setup.py sdist
$ cd dist/
$ tar -xvf simple-pid-0.2.4.tar.gz
$ tree simple-pid-0.2.4
simple-pid-0.2.4
├── PKG-INFO
├── README.md
├── setup.cfg
├── setup.py
├── simple_pid
│   ├── PID.py
│   └── __init__.py
└── simple_pid.egg-info
    ├── PKG-INFO
    ├── SOURCES.txt
    ├── dependency_links.txt
    ├── not-zip-safe
    ├── requires.txt
    └── top_level.txt

2 directories, 12 files
```

### After the fix:
```bash
$ cd ..
$ git clean -dfx
$ git checkout add-manifest
$ python setup.py sdist
$ cd dist/
$ tar -xvf simple-pid-0.2.4.tar.gz
$ tree simple-pid-0.2.4
simple-pid-0.2.4
├── CHANGELOG.md
├── LICENSE.md
├── MANIFEST.in
├── PKG-INFO
├── README.md
├── docs
│   ├── Makefile
│   ├── requirements.txt
│   └── source
│       ├── conf.py
│       ├── index.rst
│       └── simple_pid.rst
├── examples
│   └── water_boiler
│       ├── README.md
│       ├── requirements.txt
│       └── water_boiler.py
├── setup.cfg
├── setup.py
├── simple_pid
│   ├── PID.py
│   ├── PID.pyi
│   ├── __init__.py
│   └── py.typed
└── simple_pid.egg-info
    ├── PKG-INFO
    ├── SOURCES.txt
    ├── dependency_links.txt
    ├── not-zip-safe
    ├── requires.txt
    └── top_level.txt

6 directories, 25 files
```