### PR TITLE
Implement optional bias constant

### DIFF
--- a/README.md
+++ b/README.md
@@ -116,6 +116,29 @@ def pi_clip(angle):
 pid.error_map = pi_clip
 ```
 
+#### Output Bias
+
+An optional bias constant can be provided when creating a `PID` instance. This constant
+is applied to the output before any output limits are applied. This can be useful for systems
+which require a non-zero output to maintain a steady-state.
+
+For example, in a simple proportional-only mode, the PID output will be zero when the error
+is zero ie. the system has reached the setpoint:
+
+```python
+>>> pid = PID(1, 0, 0, setpoint=10)
+>>> pid(10)
+0.0
+```
+
+But when we apply a bias constant, our steady-state output is equal to the bias:
+
+```python
+>>> pid = PID(1, 0, 0, setpoint=10, bias=5)
+>>> pid(10)
+5.0
+```
+
 ## Tests
 Use the following to run tests:
 ```

--- a/simple_pid/PID.py
+++ b/simple_pid/PID.py
@@ -36,6 +36,7 @@ class PID(object):
         auto_mode=True,
         proportional_on_measurement=False,
         error_map=None,
+        bias=0,
     ):
         """
         Initialize a new PID controller.
@@ -59,6 +60,7 @@ class PID(object):
             the input directly rather than on the error (which is the traditional way). Using
             proportional-on-measurement avoids overshoot for some types of systems.
         :param error_map: Function to transform the error value in another constrained value.
+        :param bias: Constant output bias. Applied before output limits.
         """
         self.Kp, self.Ki, self.Kd = Kp, Ki, Kd
         self.setpoint = setpoint
@@ -68,6 +70,7 @@ class PID(object):
         self._auto_mode = auto_mode
         self.proportional_on_measurement = proportional_on_measurement
         self.error_map = error_map
+        self.bias = bias
 
         self._proportional = 0
         self._integral = 0
@@ -127,7 +130,7 @@ class PID(object):
         self._derivative = -self.Kd * d_input / dt
 
         # Compute final output
-        output = self._proportional + self._integral + self._derivative
+        output = self._proportional + self._integral + self._derivative + self.bias
         output = _clamp(output, self.output_limits)
 
         # Keep track of state
@@ -143,8 +146,9 @@ class PID(object):
             'Kp={self.Kp!r}, Ki={self.Ki!r}, Kd={self.Kd!r}, '
             'setpoint={self.setpoint!r}, sample_time={self.sample_time!r}, '
             'output_limits={self.output_limits!r}, auto_mode={self.auto_mode!r}, '
-            'proportional_on_measurement={self.proportional_on_measurement!r},'
-            'error_map={self.error_map!r}'
+            'proportional_on_measurement={self.proportional_on_measurement!r}, '
+            'error_map={self.error_map!r}, '
+            'bias={self.bias!r}'
             ')'
         ).format(self=self)
 

--- a/simple_pid/PID.pyi
+++ b/simple_pid/PID.pyi
@@ -17,6 +17,7 @@ class PID(object):
     output_limits: _Limits
     proportional_on_measurement: bool
     error_map: Optional[Callable[[float], float]]
+    bias: Optional[float]
     def __init__(
         self,
         Kp: float = ...,
@@ -28,6 +29,7 @@ class PID(object):
         auto_mode: bool = ...,
         proportional_on_measurement: bool = ...,
         error_map: Optional[Callable[[float], float]] = ...,
+        bias: Optional[float] = ...,
     ) -> None: ...
     def __call__(self, input_: float, dt: Optional[float] = ...) -> Optional[float]: ...
     def __repr__(self) -> str: ...

--- a/tests/test_pid.py
+++ b/tests/test_pid.py
@@ -237,3 +237,26 @@ def test_error_map():
 
     # Check if error value is mapped by the function
     assert pid(pv) == pi_clip(sp - pv)
+
+
+def test_bias():
+    bias = 5
+    setpoint = 10
+    kp = 1
+    upper_limit = 20
+    lower_limit = 0
+
+    pid = PID(
+        kp,
+        0,
+        0,
+        setpoint=setpoint,
+        sample_time=None,
+        bias=bias,
+        output_limits=(lower_limit, upper_limit)
+    )
+
+    assert pid(setpoint) == bias
+    assert pid(setpoint - 5) == bias + (kp * 5)
+    assert pid(setpoint - 50) == upper_limit
+    assert pid(setpoint + 50) == lower_limit


### PR DESCRIPTION
Add a new optional argument to the PID class which allows a constant output bias to be specified. If provided this bias is applied to the output before any output limits are applied. This can be useful for systems which require a non-zero output to maintain a steady-state.

This new argument is optional and defaults to zero, so existing users of the package won't notice any changes. The implementation itself is also trivial.

I've been using a bias constant in a system I'm currently working on by using a `PID` instance without output limits, then applying the bias and output limits myself, *after* calling the PID instance. This works fine, but it's definitiely neater and more efficient to be able to let the PID take care of all the limits internally.

Interested to hear if you think this would be worth having @m-lundberg . Let me know if there's anything else I need to add to this PR. Thanks for your work on this package, I've found it great to work with!