### PR TITLE
Fix mypy issue by using an explicit export

### DIFF
--- a/simple_pid/__init__.py
+++ b/simple_pid/__init__.py
@@ -1,1 +1,1 @@
-from .PID import PID
+from simple_pid.PID import PID as PID


### PR DESCRIPTION
Fixes the following error when running mypy in `--strict` mode:

    error: Module "simple_pid" does not explicitly export attribute "PID";

Fixes #48