### PR TITLE
Remove duplicate output_limits definition

### DIFF
--- a/simple_pid/PID.pyi
+++ b/simple_pid/PID.pyi
@@ -14,7 +14,6 @@ class PID(object):
     Kd: float
     setpoint: float
     sample_time: Optional[float]
-    output_limits: _Limits
     proportional_on_measurement: bool
     error_map: Optional[Callable[[float], float]]
     def __init__(


### PR DESCRIPTION
Fixes the following mypy error:

    simple_pid/PID.pyi:45: error: Name "output_limits" already defined on line 17

Fixes #50