### PR TITLE
CI: add a workflow to run examples

### DIFF
--- a/.github/workflows/run-examples.yml
+++ b/.github/workflows/run-examples.yml
@@ -34,7 +34,7 @@ jobs:
         # interactively.
         # pip install pyqt5
 
-    - name: Run tests with pytest
+    - name: Run examples
       run: |
         cd examples/water_boiler/
         NO_DISPLAY=1 python water_boiler.py

--- a/.github/workflows/run-examples.yml
+++ b/.github/workflows/run-examples.yml
@@ -29,7 +29,10 @@ jobs:
       run: |
         python -m pip install --upgrade pip
         python -m pip install -r examples/water_boiler/requirements.txt
-        pip install pyqt5
+        # The pyqt5 package may not be needed for non-interactive runs (such as
+        # in this CI), but may be needed as a backend for Matplotlib to run
+        # interactively.
+        # pip install pyqt5
 
     - name: Run tests with pytest
       run: |

--- a/.github/workflows/run-examples.yml
+++ b/.github/workflows/run-examples.yml
@@ -1,0 +1,42 @@
+name: examples
+
+on:
+  push:
+    # branches: [ master ]
+  pull_request:
+    # branches: [ master ]
+  workflow_dispatch:
+
+jobs:
+  build:
+
+    name: Run examples
+    runs-on: ubuntu-latest
+    strategy:
+      fail-fast: false
+      matrix:
+        python-version: ["3.6", "3.7", "3.8", "3.9", "3.10", "pypy-3.9"]
+
+    steps:
+    - uses: actions/checkout@v3
+
+    - name: Set up Python ${{ matrix.python-version }}
+      uses: actions/setup-python@v3
+      with:
+        python-version: ${{ matrix.python-version }}
+
+    - name: Install dependencies
+      run: |
+        python -m pip install --upgrade pip
+        python -m pip install -r examples/water_boiler/requirements.txt
+        pip install pyqt5
+
+    - name: Run tests with pytest
+      run: |
+        cd examples/water_boiler/
+        NO_DISPLAY=1 python water_boiler.py
+
+    - name: Upload resulting figures
+      uses: actions/upload-artifact@v3
+      with:
+        path: examples/water_boiler/result-py${{ matrix.python-version }}.png

--- a/.github/workflows/run-examples.yml
+++ b/.github/workflows/run-examples.yml
@@ -15,7 +15,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        python-version: ["3.6", "3.7", "3.8", "3.9", "3.10", "pypy-3.9"]
+        python-version: ["3.7", "3.8", "3.9", "3.10"]
 
     steps:
     - uses: actions/checkout@v3
@@ -39,4 +39,5 @@ jobs:
     - name: Upload resulting figures
       uses: actions/upload-artifact@v3
       with:
+        name: result-py${{ matrix.python-version }}.png
         path: examples/water_boiler/result-py${{ matrix.python-version }}.png

--- a/examples/water_boiler/water_boiler.py
+++ b/examples/water_boiler/water_boiler.py
@@ -1,5 +1,7 @@
 #!/usr/bin/env python
 
+import os
+import sys
 import time
 import matplotlib.pyplot as plt
 from simple_pid import PID
@@ -58,4 +60,7 @@ if __name__ == '__main__':
     plt.xlabel('time')
     plt.ylabel('temperature')
     plt.legend()
-    plt.show()
+    if os.getenv("NO_DISPLAY"):
+        plt.savefig(f"result-py{'.'.join([str(x) for x in sys.version_info[:2]])}.png")
+    else:
+        plt.show()

--- a/examples/water_boiler/water_boiler.py
+++ b/examples/water_boiler/water_boiler.py
@@ -60,7 +60,7 @@ if __name__ == '__main__':
     plt.xlabel('time')
     plt.ylabel('temperature')
     plt.legend()
-    if os.getenv("NO_DISPLAY"):
+    if os.getenv('NO_DISPLAY'):
         plt.savefig(f"result-py{'.'.join([str(x) for x in sys.version_info[:2]])}.png")
     else:
         plt.show()


### PR DESCRIPTION
This is prompted by the report in #59. The new workflow is supposed to run for Python 3.7-3.10 (there is no NumPy 1.21 version for Python 3.6) and produce plots after running the `water_boiler.py` example. The resulting plots are then uploaded to GHA's summary page (in a .zip archive) so that one can see the results of the run.

