### PR TITLE
Revert "Keep pid call uniform with update function"

### DIFF
--- a/examples/water_boiler/water_boiler.py
+++ b/examples/water_boiler/water_boiler.py
@@ -43,7 +43,7 @@ if __name__ == '__main__':
         current_time = time.time()
         dt = current_time - last_time
 
-        power = pid(water_temp, dt)
+        power = pid(water_temp)
         water_temp = boiler.update(power, dt)
 
         x += [current_time - start_time]


### PR DESCRIPTION
Reverts m-lundberg/simple-pid#81 since it causes the produced plot to show that the measured value always stays at 0. Will need to investigate more closely why that is.